### PR TITLE
Added FileHeader along with it's Characteristics

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,6 +16,12 @@ type Section struct {
 	Size       int64  `json:"Size"`
 }
 
+type FileHeader struct {
+	Machine         string `json:"Machine"`
+	TimeDateStamp   string `json:"TimeDateStamp"`
+	Characteristics uint16 `json:"Characteristics"`
+}
+
 type PEFile struct {
 	nt_header *IMAGE_NT_HEADERS
 
@@ -25,11 +31,10 @@ type PEFile struct {
 	// The file offset to the resource section.
 	resource_base int64
 
-	Machine       string     `json:"Machine"`
-	TimeDateStamp string     `json:"TimeDateStamp"`
-	GUIDAge       string     `json:"GUIDAge"`
-	PDB           string     `json:"PDB"`
-	Sections      []*Section `json:"Sections"`
+	FileHeader FileHeader `json:"FileHeader"`
+	GUIDAge    string     `json:"GUIDAge"`
+	PDB        string     `json:"PDB"`
+	Sections   []*Section `json:"Sections"`
 
 	VersionInformation map[string]string `json:"VersionInformation"`
 
@@ -127,10 +132,13 @@ func NewPEFile(reader io.ReaderAt) (*PEFile, error) {
 		nt_header:     nt_header,
 		rva_resolver:  rva_resolver,
 		resource_base: resource_base,
-		Machine:       file_header.Machine().Name,
-		TimeDateStamp: file_header.TimeDateStamp().String(),
-		GUIDAge:       rsds.GUIDAge(),
-		PDB:           rsds.Filename(),
+		FileHeader: FileHeader{
+			Machine:         file_header.Machine().Name,
+			TimeDateStamp:   file_header.TimeDateStamp().String(),
+			Characteristics: file_header.Characteristics(),
+		},
+		GUIDAge: rsds.GUIDAge(),
+		PDB:     rsds.Filename(),
 		VersionInformation: GetVersionInformation(
 			nt_header, rva_resolver, resource_base),
 		Imports: GetImports(nt_header, rva_resolver),

--- a/conversion.spec.yaml
+++ b/conversion.spec.yaml
@@ -55,7 +55,7 @@ FieldWhiteList:
   _IMAGE_SECTION_HEADER: [PointerToRawData, VirtualAddress,
        Characteristics, SizeOfRawData, Name]
   _IMAGE_FILE_HEADER: [SizeOfOptionalHeader, TimeDateStamp,
-       NumberOfSections, Machine]
+       NumberOfSections, Machine, Characteristics]
   _IMAGE_EXPORT_DIRECTORY: [Name, Base, NumberOfFunctions, NumberOfNames, AddressOfFunctions, AddressOfNames, AddressOfNameOrdinals]
   _IMAGE_RESOURCE_DIRECTORY: [_Entries, NumberOfIdEntries, NumberOfNamedEntries]
   _IMAGE_RESOURCE_DIRECTORY_ENTRY: [NameIsString, NameOffset, Type,

--- a/pe_gen.go
+++ b/pe_gen.go
@@ -84,6 +84,7 @@ type PeProfile struct {
 	Off_IMAGE_EXPORT_DIRECTORY_Name                      int64
 	Off_IMAGE_EXPORT_DIRECTORY_NumberOfFunctions         int64
 	Off_IMAGE_EXPORT_DIRECTORY_NumberOfNames             int64
+	Off_IMAGE_FILE_HEADER_Characteristics                int64
 	Off_IMAGE_FILE_HEADER_Machine                        int64
 	Off_IMAGE_FILE_HEADER_NumberOfSections               int64
 	Off_IMAGE_FILE_HEADER_SizeOfOptionalHeader           int64
@@ -130,7 +131,7 @@ type PeProfile struct {
 
 func NewPeProfile() *PeProfile {
 	// Specific offsets can be tweaked to cater for slight version mismatches.
-	self := &PeProfile{0, 4, 20, 24, 0, 4, 8, 0, 4, 0, 2, 4, 0, 2, 0, 2, 4, 6, 0, 2, 4, 6, 0, 2, 4, 6, 0, 2, 4, 6, 0, 4, 6, 8, 4, 0, 20, 4, 12, 60, 0, 28, 36, 32, 16, 12, 20, 24, 0, 2, 16, 4, 2, 0, 12, 0, 4, 24, 0, 96, 28, 0, 112, 24, 0, 0, 4, 8, 14, 12, 16, 0, 4, 0, 0, 4, 4, 36, 0, 20, 16, 12, 0, 0, 0, 0, 0, 0, 0, 0}
+	self := &PeProfile{0, 4, 20, 24, 0, 4, 8, 0, 4, 0, 2, 4, 0, 2, 0, 2, 4, 6, 0, 2, 4, 6, 0, 2, 4, 6, 0, 2, 4, 6, 0, 4, 6, 8, 4, 0, 20, 4, 12, 60, 0, 28, 36, 32, 16, 12, 20, 24, 18, 0, 2, 16, 4, 2, 0, 12, 0, 4, 24, 0, 96, 28, 0, 112, 24, 0, 0, 4, 8, 14, 12, 16, 0, 4, 0, 0, 4, 4, 36, 0, 20, 16, 12, 0, 0, 0, 0, 0, 0, 0, 0}
 	return self
 }
 
@@ -702,7 +703,6 @@ func (self *IMAGE_EXPORT_DIRECTORY) Base() uint32 {
 }
 
 func (self *IMAGE_EXPORT_DIRECTORY) Name() uint32 {
-	fmt.Println("Offset:", self.Offset)
 	return ParseUint32(self.Reader, self.Profile.Off_IMAGE_EXPORT_DIRECTORY_Name+self.Offset)
 }
 
@@ -733,6 +733,10 @@ type IMAGE_FILE_HEADER struct {
 
 func (self *IMAGE_FILE_HEADER) Size() int {
 	return 20
+}
+
+func (self *IMAGE_FILE_HEADER) Characteristics() uint16 {
+	return ParseUint16(self.Reader, self.Profile.Off_IMAGE_FILE_HEADER_Characteristics+self.Offset)
 }
 
 func (self *IMAGE_FILE_HEADER) Machine() *Enumeration {
@@ -768,6 +772,7 @@ func (self *IMAGE_FILE_HEADER) TimeDateStamp() *UnixTimeStamp {
 }
 func (self *IMAGE_FILE_HEADER) DebugString() string {
 	result := fmt.Sprintf("struct IMAGE_FILE_HEADER @ %#x:\n", self.Offset)
+	result += fmt.Sprintf("  Characteristics: %#0x\n", self.Characteristics())
 	result += fmt.Sprintf("  Machine: %v\n", self.Machine().DebugString())
 	result += fmt.Sprintf("  NumberOfSections: %#0x\n", self.NumberOfSections())
 	result += fmt.Sprintf("  SizeOfOptionalHeader: %#0x\n", self.SizeOfOptionalHeader())


### PR DESCRIPTION
This adds a new structure called `FileHeader` where `Machine` and `TimeDateStamp` have been moved to along with a new field `Characteristics`. This is a breaking change but hopefully with Go modules it'll be fine :)

This library has been super helpful for us in some binary analysis tools where Go's `debug/pe` is too strict and often fails or panic's due to weird PE's :) 