### PR TITLE
Handle null resource_base

### DIFF
--- a/api.go
+++ b/api.go
@@ -79,9 +79,13 @@ func GetVersionInformation(
 	resource_base int64) map[string]string {
 	result := make(map[string]string)
 
+	resourceDirectory := nt_header.ResourceDirectory(rva_resolver)
+	if resource_base == 0 {
+		resource_base = resourceDirectory.Offset
+	}
+
 	// Find the RT_VERSION resource.
-	for _, entry := range nt_header.
-		ResourceDirectory(rva_resolver).Entries() {
+	for _, entry := range resourceDirectory.Entries() {
 
 		if entry.NameString(resource_base) == "RT_VERSION" {
 			for _, child := range entry.Traverse(resource_base) {


### PR DESCRIPTION
Some PEs, such as .NET 64 Assemblies don't have a `.rsrc` section but still have a Resource Directory.
In that case, the base RVA/offset to use would be the base of the IMAGE_RESOURCE_DIRECTORY itself. This way it's possible to extract version information from those binaries as well.