### PR TITLE
fix Chinese character problem

### DIFF
--- a/pe_gen.go
+++ b/pe_gen.go
@@ -1456,6 +1456,9 @@ func ParseTerminatedUTF16String(reader io.ReaderAt, offset int64) string {
    if idx < 0 {
       idx = n-1
    }
+   if idx%2 == 0 {
+      idx -= 1
+   }
    return UTF16BytesToUTF8(data[0:idx+1], binary.LittleEndian)
 }
 


### PR DESCRIPTION
 fix the problem of incorrect parsing of Chinese characters at the end.

When the end is a Chinese character, it will cause an additional unknown character in the parsing result.