### PR TITLE
fix Chinese character problem

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,7 @@
 package pe
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -92,4 +93,12 @@ func TestCatParser(t *testing.T) {
 		goldie.WithNameSuffix(".golden"),
 		goldie.WithDiffEngine(goldie.ColoredDiff))
 	g.AssertJson(t, "TestCatalog", dict)
+}
+
+func TestUTFParser(t *testing.T) {
+	en := []uint8{72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 87, 0, 111, 0, 114, 0, 108, 0, 100, 0, 0, 0, 74, 0, 0, 0}
+	zh := []uint8{96, 79, 125, 89, 22, 78, 76, 117, 0, 0, 0, 0, 74, 0, 0, 0}
+
+	assert.Equal(t, ParseTerminatedUTF16String(bytes.NewReader(en), 0), "HelloWorld")
+	assert.Equal(t, ParseTerminatedUTF16String(bytes.NewReader(zh), 0), "你好世界")
 }

--- a/pe_gen.go
+++ b/pe_gen.go
@@ -1456,6 +1456,9 @@ func ParseTerminatedUTF16String(reader io.ReaderAt, offset int64) string {
    if idx < 0 {
       idx = n-1
    }
+   if idx%2 == 0 {
+      idx -= 1
+   }
    return UTF16BytesToUTF8(data[0:idx+1], binary.LittleEndian)
 }
 


### PR DESCRIPTION
fix the problem of incorrect parsing of Chinese characters at the end

When the end is a Chinese character, it will cause an additional unknown character in the parsing result.