### PR TITLE
Allow callers to set maximum size of the file

### DIFF
--- a/api.go
+++ b/api.go
@@ -44,6 +44,7 @@ type FileHeader struct {
 type PEFile struct {
 	mu sync.Mutex
 
+	max_size   int64
 	dos_header *IMAGE_DOS_HEADER
 	nt_header  *IMAGE_NT_HEADERS
 
@@ -338,6 +339,10 @@ func GetVersionInformation(
 }
 
 func NewPEFile(reader io.ReaderAt) (*PEFile, error) {
+	return NewPEFileWithSize(reader, 0)
+}
+
+func NewPEFileWithSize(reader io.ReaderAt, max_size int64) (*PEFile, error) {
 	profile := NewPeProfile()
 	dos_header := profile.IMAGE_DOS_HEADER(reader, 0)
 	if dos_header.E_magic() != 0x5a4d {
@@ -358,6 +363,7 @@ func NewPEFile(reader io.ReaderAt) (*PEFile, error) {
 	file_header := nt_header.FileHeader()
 
 	result := &PEFile{
+		max_size:      max_size,
 		dos_header:    dos_header,
 		nt_header:     nt_header,
 		rva_resolver:  rva_resolver,

--- a/authenticode.go
+++ b/authenticode.go
@@ -142,20 +142,28 @@ func (self *PEFile) CalcHash() *Hashes {
 	DebugPrint("Second range %d-%d\n", start_of_checksum+4, security_dir.Offset)
 	wrapper.CopyRange(writer, start_of_checksum+4, security_dir.Offset)
 
-	optional_header := self.nt_header.OptionalHeader()
-
-	// The SizeOfHeaders is the end of the entire first part of
-	// the file (including all headers). After that there are sections.
-	wrapper.CopyRange(writer, security_dir.Offset+8,
-		int64(optional_header.SizeOfHeaders()))
-	DebugPrint("range %d-%d\n",
-		security_dir.Offset+8, int64(optional_header.SizeOfHeaders()))
-
 	// Sort the sections in ascending file offset order.
 	sections := self.nt_header.Sections()
 	sort.Slice(sections, func(i, j int) bool {
 		return sections[i].PointerToRawData() < sections[j].PointerToRawData()
 	})
+
+	if len(sections) == 0 {
+		return hasher
+	}
+
+	optional_header := self.nt_header.OptionalHeader()
+
+	// If the max size is exceeded then dont bother reading.
+	end := int64(optional_header.SizeOfHeaders())
+	if self.max_size > 0 && end > self.max_size {
+		return hasher
+	}
+
+	// The SizeOfHeaders is the end of the entire first part of
+	// the file (including all headers). After that there are sections.
+	wrapper.CopyRange(writer, security_dir.Offset+8, end)
+	DebugPrint("range %d-%d\n", security_dir.Offset+8, end)
 
 	// Write the sections into the hash
 	for _, section := range sections {


### PR DESCRIPTION
We can use this to reject unreasonably large read requests